### PR TITLE
Renaming dashd variable into vivod

### DIFF
--- a/lib/models.py
+++ b/lib/models.py
@@ -145,7 +145,7 @@ class GovernanceObject(BaseModel):
 
             sub, params = subclass(**newdikt), []
             if isinstance(sub, Watchdog):
-                params = [dashd]
+                params = [vivod]
 
             if sub.is_valid(*params) is False:
                 govobj.vote_delete(vivod)


### PR DESCRIPTION
Because of the partial renaming, the dashd variable didn't exist, causing the sentinel to crash.

Since I made the original patch that you applied a few days ago, I took the time to fix this as well.

We are quite happy you are active again. 

Kevin, from the Tetricoins team